### PR TITLE
Remove heapq from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 numpy
 scipy
-heapq
 shapely
 matplotlib


### PR DESCRIPTION
The `heapq` module was removed from the requirements.txt file due to its inclusion in Python's standard library. There's no need to list it among the requirements, as it's available in all Python environments.